### PR TITLE
Seperated out keeplocal and keepremote in finish feature.

### DIFF
--- a/GitFlow.VS.Extension/UI/GitFlowActionsUI.xaml
+++ b/GitFlow.VS.Extension/UI/GitFlowActionsUI.xaml
@@ -131,14 +131,16 @@
                 <RowDefinition></RowDefinition>
                 <RowDefinition></RowDefinition>
                 <RowDefinition></RowDefinition>
+                <RowDefinition></RowDefinition>
             </Grid.RowDefinitions>
                 <ComboBox Grid.Row="0" Margin="-2,0,0,6" VerticalAlignment="Center"
                     IsEditable="false" IsReadOnly="true" DisplayMemberPath="Name"
                     ItemsSource="{Binding Path=AllFeatures, UpdateSourceTrigger=PropertyChanged}"
                     SelectedItem="{Binding Path=SelectedFeature, Mode=TwoWay}"/>
                 <CheckBox Grid.Row="1" IsChecked="{Binding FeatureRebaseOnDevelopmentBranch}">Rebase on development branch</CheckBox>
-            <CheckBox Grid.Row="2"  IsChecked="{Binding FeatureDeleteBranch}">Delete branch</CheckBox>
-            <StackPanel Grid.Row="3" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="0,10,0,0" >
+            <CheckBox Grid.Row="2"  IsChecked="{Binding FeatureDeleteLocalBranch}">Delete local branch</CheckBox>
+            <CheckBox Grid.Row="3"  IsChecked="{Binding FeatureDeleteRemoteBranch}">Delete remote branch</CheckBox>
+            <StackPanel Grid.Row="4" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="0,10,0,0" >
                 <Button Command="{Binding FinishFeatureCommand}">OK</Button>
                     <teamExplorer:TextLink x:Uid="cancelFinishFeature" VerticalAlignment="Center" Margin="6,0,0,0" Text="Cancel"
                           Localization.Attributes="Text (Modifiable Readable Text)"

--- a/GitFlow.VS.Extension/ViewModels/ActionViewModel.cs
+++ b/GitFlow.VS.Extension/ViewModels/ActionViewModel.cs
@@ -23,7 +23,8 @@ namespace GitFlowVS.Extension.ViewModels
         private string hotfixName;
 
         private bool featureRebaseOnDevelopmentBranch;
-        private bool featureDeleteBranch;
+        private bool featureDeleteLocalBranch;
+        private bool featureDeleteRemoteBranch;
         private bool releaseDeleteBranch;
         private string releaseTagMessage;
         private bool releaseForceDeletion;
@@ -68,7 +69,8 @@ namespace GitFlowVS.Extension.ViewModels
         public ActionViewModel(GitFlowActionSection te)
             : base(te)
         {
-            FeatureDeleteBranch = true;
+            FeatureDeleteLocalBranch = true;
+            FeatureDeleteRemoteBranch = true;
             ReleaseDeleteBranch = true;
             ReleaseTagMessageSelected = true;
             HotfixDeleteBranch = true;
@@ -457,7 +459,8 @@ namespace GitFlowVS.Extension.ViewModels
                 var properties = new Dictionary<string, string>
                 {
                     {"RebaseOnDevelopmentBranch", FeatureRebaseOnDevelopmentBranch.ToString()},
-                    {"DeleteBranch", FeatureDeleteBranch.ToString()}
+                    {"DeleteLocalBranch", FeatureDeleteLocalBranch.ToString()},
+                    {"DeleteRemoteBranch", FeatureDeleteRemoteBranch.ToString()}
                 };
                 Logger.Event("FinishFeature", properties);
 
@@ -468,7 +471,7 @@ namespace GitFlowVS.Extension.ViewModels
                     ShowProgressBar();
 
                     var gf = new VsGitFlowWrapper(GitFlowPage.ActiveRepoPath, GitFlowPage.OutputWindow);
-                    var result = gf.FinishFeature(SelectedFeature.Name, FeatureRebaseOnDevelopmentBranch, FeatureDeleteBranch);
+                    var result = gf.FinishFeature(SelectedFeature.Name, FeatureRebaseOnDevelopmentBranch, FeatureDeleteLocalBranch, FeatureDeleteRemoteBranch);
                     if (!result.Success)
                     {
                         ShowErrorMessage(result);
@@ -706,13 +709,23 @@ namespace GitFlowVS.Extension.ViewModels
             }
         }
 
-        public bool FeatureDeleteBranch
+        public bool FeatureDeleteLocalBranch
         {
-            get { return featureDeleteBranch; }
+            get { return featureDeleteLocalBranch; }
             set
             {
-                if (value.Equals(featureDeleteBranch)) return;
-                featureDeleteBranch = value;
+                if (value.Equals(featureDeleteLocalBranch)) return;
+                featureDeleteLocalBranch = value;
+                OnPropertyChanged();
+            }
+        }
+        public bool FeatureDeleteRemoteBranch
+        {
+            get { return featureDeleteRemoteBranch; }
+            set
+            {
+                if (value.Equals(featureDeleteRemoteBranch)) return;
+                featureDeleteRemoteBranch = value;
                 OnPropertyChanged();
             }
         }

--- a/GitFlow.VS/GitFlowWrapper.cs
+++ b/GitFlow.VS/GitFlowWrapper.cs
@@ -311,13 +311,16 @@ namespace GitFlow.VS
             return RunGitFlow(gitArguments);
         }
 
-        public GitFlowCommandResult FinishFeature(string featureName, bool rebaseOnDevelopment = false, bool deleteBranch = true)
+        public GitFlowCommandResult FinishFeature(string featureName, bool rebaseOnDevelopment = false, bool deleteLocalBranch = true, bool deleteRemoteBranch = true)
         {
             string gitArguments = "feature finish \"" + TrimBranchName(featureName) + "\"";
             if (rebaseOnDevelopment)
                 gitArguments += " -r";
-            if (!deleteBranch)
-                gitArguments += " -k";
+            if (!deleteLocalBranch)
+                gitArguments += " --keeplocal";
+            if (!deleteRemoteBranch)
+                gitArguments += " --keepremote";
+
 
             return RunGitFlow(gitArguments);
 


### PR DESCRIPTION
This replaces the "Delete branch" checkbox with "Delete local branch" and "Delete remote branch". These options are then mapped to the keeplocal and keepremote parameters to gitflow.